### PR TITLE
Endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,15 @@ For your convenience, there is a standard whitelist available. Use it at your ow
 oembetter.whitelist(oembetter.suggestedWhitelist);
 ```
 
+## Suggesting Endpoints
+
+Some services support `oembed` but aren't discoverable. You can tell oembetter where to point for the oembed api by passing in an array of endpoints. 
+
+```javascript
+oembetter.endpoints([
+  {domain: 'instagram.com', endpoint: 'http://api.instagram.com/oembed'}
+]);
+```
 
 ## Adding Filters
 

--- a/index.js
+++ b/index.js
@@ -190,6 +190,10 @@ module.exports = function(options) {
     'twitter.com'
   ];
 
+  self.suggestedEndpoints = [
+    {domain: 'instagram.com', endpoint: 'http://api.instagram.com/oembed' }
+  ];
+
   self.endpoints = function(_endpoints) {
     self._endpoints = _endpoints;
   };

--- a/index.js
+++ b/index.js
@@ -48,6 +48,15 @@ module.exports = function(options) {
         return callback(new Error('oembetter: ' + url + ' is not in a whitelisted domain.'));
       }
     }
+    var endpoint = false;
+    if (self._endpoints) {
+      for (i = 0; i < self._endpoints.length; i++) {
+        if (self.inDomain(self._endpoints[i].domain, parsed.hostname)) {
+          endpoint = self._endpoints[i].endpoint;
+          break;
+        }
+      }
+    }
     return async.series({
       before: function(callback) {
         return async.eachSeries(self.before, function(before, callback) {
@@ -69,7 +78,7 @@ module.exports = function(options) {
           // Preempted by a before
           return callback(null);
         }
-        return oembed(url, options, function (err, result) {
+        return oembed(url, options, endpoint, function (err, result) {
           response = result;
           if (err) {
             // not necessarily fatal
@@ -176,8 +185,14 @@ module.exports = function(options) {
     'dotsub.com',
     'yfrog.com',
     'photobucket.com',
-    'soundcloud.com'
+    'soundcloud.com',
+    'instagram.com',
+    'twitter.com'
   ];
+
+  self.endpoints = function(_endpoints) {
+    self._endpoints = _endpoints;
+  };
 
   return self;
 };


### PR DESCRIPTION
This is the work we did together on adding endpoints to domains that aren't discoverable. This never made it into core.

If this looks good and you accept it, you'll need to add the following line to `lib/videos.js` in apostrophe to take advantage of it, just below where we configure the whitelist:
```javascript
oembetter.endpoints(oembetter.suggestedEndpoints);
```