### PR TITLE
Fix fetch options example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ You can pass an object containing `maxwidth` and `maxheight` options. Sites vary
 ```javascript
 var oembetter = require('oembetter')();
 
-oembetter.fetch(url, function(err, { maxwidth: 480, maxheight: 480 }, response) {
+oembetter.fetch(url, { maxwidth: 480, maxheight: 480 }, function(err, response) {
   if (!err) {
     // response.html contains markup to embed the video or
     // whatever it might be


### PR DESCRIPTION
Just a quick fix to one of the examples in the docs.

If you're open to it I'd open a second PR expanding this section to explain that you can specify more options than just `maxHeight` and `maxWidth`. I had to look through the code to determine that. Which is easy enough to read through but it would be good to say out front that you can pass all options.

👍 Great library. Easy to setup and saved me a bunch of time.