### PR TITLE
Fix sharing links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
-## UNRELEASED
+## 1.1.4 (2024-08-07)
 
-- Hardcode the YouTube oembed endpoint for sharing URLs too.
+- Followup to 1.1.3: also hardcode the YouTube oembed endpoint for sharing URLs (`youtu.be`).
 
 ## 1.1.3 (2024-08-07)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## UNRELEASED
+
+- Hardcode the YouTube oembed endpoint for sharing URLs too.
+
 ## 1.1.3 (2024-08-07)
 
 - Hardcode the well-known YouTube oembed endpoint. While YouTube still does output oembed metadata, today many users saw broken videos due to broken canonical tags on YouTube pages (`link rel="undefined"`), which hampered discovery. Also this heavily used service will benefit from one less request per video.

--- a/index.js
+++ b/index.js
@@ -229,6 +229,10 @@ module.exports = function(options) {
     {
       domain: 'youtube.com',
       endpoint: 'https://www.youtube.com/oembed'
+    },
+    {
+      domain: 'youtu.be',
+      endpoint: 'https://www.youtube.com/oembed'
     }
   ];
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oembetter",
-  "version": "1.1.3",
+  "version": "1.1.4-alpha.1",
   "description": "A modern oembed client. Allows you to register filters to improve or supply oembed support for sites that don't normally have it. You can also supply a allowlist of services you trust to prevent XSS attacks.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oembetter",
-  "version": "1.1.4-alpha.1",
+  "version": "1.1.4",
   "description": "A modern oembed client. Allows you to register filters to improve or supply oembed support for sites that don't normally have it. You can also supply a allowlist of services you trust to prevent XSS attacks.",
   "main": "index.js",
   "scripts": {

--- a/tests/test.js
+++ b/tests/test.js
@@ -79,8 +79,24 @@ describe('oembetter', function() {
       return done();
     });
   });
-  it('should return an oembed response for youtube', function(done) {
+  it('should return an oembed response for youtube full links', function(done) {
+    const oembetter = require('../index.js')();
+    // Use the suggested endpoints, youtube sometimes has discovery issues
+    // so we always do this in production
+    oembetter.endpoints(oembetter.suggestedEndpoints);
     oembetter.fetch('https://www.youtube.com/watch?v=zsl_auoGuy4', function(err, response) {
+      assert(!err);
+      assert(response);
+      assert(response.html);
+      done();
+    });
+  });
+  it('should return an oembed response for youtube sharing links', function(done) {
+    const oembetter = require('../index.js')();
+    // Use the suggested endpoints, youtube sometimes has discovery issues
+    // so we always do this in production
+    oembetter.endpoints(oembetter.suggestedEndpoints);
+    oembetter.fetch('https://youtu.be/RRfHbyCQDCo?si=U5yxvQeXgACwajqa', function(err, response) {
       assert(!err);
       assert(response);
       assert(response.html);


### PR DESCRIPTION
youtu.be needs the same treatment. In addition to making sure it works in mocha tests that ensure the configured endpoint is used (as it is in apostrophe), I got confirmation from an end user who could not embed `youtu.be` with 1.1.3 via an alpha release.